### PR TITLE
Fix module loading for orbit demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <title>FireFlight Orbit Demo</title>
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+        "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/"
+      }
+    }
+  </script>
   <style>
     body { margin: 0; overflow: hidden; }
     canvas { display: block; }

--- a/main.js
+++ b/main.js
@@ -1,5 +1,5 @@
-import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
 // Scene setup
 const scene = new THREE.Scene();


### PR DESCRIPTION
### Motivation
- The demo failed to load in the browser because remote module specifiers were used directly and the browser could not resolve Three.js addon paths. 

### Description
- Add an `importmap` to `index.html` mapping `three` and `three/addons/` to unpkg CDN module URLs so the browser can resolve bare specifiers. 
- Update `main.js` imports to use the bare specifiers `three` and `three/addons/controls/OrbitControls.js`. 
- Modified files: `index.html` and `main.js`.

### Testing
- No automated tests were run for this static front-end change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981c15055a48326b56dbe482d1294f5)