### PR TITLE
Add sun directional lighting and live satellite Charging/Eclipse status pill

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,11 +12,41 @@
     }
   </script>
   <style>
-    body { margin: 0; overflow: hidden; }
+    body { margin: 0; overflow: hidden; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
     canvas { display: block; }
+
+    #status-pill {
+      position: fixed;
+      top: 18px;
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 10px 18px;
+      border-radius: 999px;
+      border: 2px solid;
+      font-size: 14px;
+      font-weight: 700;
+      letter-spacing: 0.2px;
+      pointer-events: none;
+      user-select: none;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+      transition: background-color 180ms ease, border-color 180ms ease, color 180ms ease;
+    }
+
+    #status-pill.charging {
+      color: #093215;
+      background: rgba(171, 237, 174, 0.95);
+      border-color: #2f9b4d;
+    }
+
+    #status-pill.eclipse {
+      color: #3b0006;
+      background: rgba(255, 146, 146, 0.95);
+      border-color: #b53333;
+    }
   </style>
 </head>
 <body>
+  <div id="status-pill" class="charging">Charging ⚡️</div>
   <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -13,6 +13,8 @@ renderer.toneMapping = THREE.ACESFilmicToneMapping;
 renderer.toneMappingExposure = 1.05;
 document.body.appendChild(renderer.domElement);
 
+const statusPill = document.getElementById('status-pill');
+
 // Camera controls
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.target.set(0, 0, 0);
@@ -24,13 +26,10 @@ controls.mouseButtons.LEFT = THREE.MOUSE.PAN;
 controls.mouseButtons.RIGHT = THREE.MOUSE.PAN;
 
 // Lighting
-scene.add(new THREE.AmbientLight(0x8ea0c8, 0.25));
-const keyLight = new THREE.DirectionalLight(0xffffff, 1.45);
-keyLight.position.set(7, 4, 7);
-scene.add(keyLight);
-const fillLight = new THREE.DirectionalLight(0x8ab0ff, 0.35);
-fillLight.position.set(-5, -2, -3);
-scene.add(fillLight);
+scene.add(new THREE.AmbientLight(0x1d304f, 0.1));
+const sunLight = new THREE.DirectionalLight(0xffffff, 2.6);
+sunLight.position.set(10, 2, 3);
+scene.add(sunLight);
 
 function loadTexture(url, { color = false } = {}) {
   const loader = new THREE.TextureLoader();
@@ -180,6 +179,30 @@ scene.add(orbitGroup);
 
 camera.position.set(0, 1.2, 4.8);
 
+const satelliteWorldPosition = new THREE.Vector3();
+const sunDirection = new THREE.Vector3();
+let currentStatus = '';
+
+function updateSatelliteStatus() {
+  satellite.getWorldPosition(satelliteWorldPosition);
+  sunDirection.copy(sunLight.position).normalize();
+
+  const isSunFacing = satelliteWorldPosition.dot(sunDirection) > 0;
+  const nextStatus = isSunFacing ? 'charging' : 'eclipse';
+
+  if (nextStatus !== currentStatus) {
+    currentStatus = nextStatus;
+
+    if (nextStatus === 'charging') {
+      statusPill.textContent = 'Charging ⚡️';
+      statusPill.className = 'charging';
+    } else {
+      statusPill.textContent = 'Eclipse 🌑';
+      statusPill.className = 'eclipse';
+    }
+  }
+}
+
 // Animation
 const clock = new THREE.Clock();
 const orbitPeriod = 10;
@@ -195,6 +218,7 @@ function animate() {
     if (outlines) outlines.rotation.y = earth.rotation.y;
   }
 
+  updateSatelliteStatus();
   controls.update();
   renderer.render(scene, camera);
 }


### PR DESCRIPTION
### Motivation
- Visually split the planet into a lit hemisphere and a shaded hemisphere so day/night contrast is clear as the Earth rotates and the satellite orbits. 
- Provide an at-a-glance UI indicator showing whether the satellite is currently sun-facing (charging) or in eclipse.

### Description
- Replace the previous multi-light setup with a low ambient light and a single stronger directional `sunLight` so the Earth displays a bright day side and a dark night side. 
- Add a top-centered status pill UI in `index.html` with styles for `charging` (light green background and darker green border) and `eclipse` (red background and darker red border). 
- Implement `updateSatelliteStatus()` in `main.js` that computes sun-facing state by taking the dot product between the satellite world position and the normalized `sunLight.position`, and update the pill text and CSS class each animation frame. 
- Wire the status update into the animation loop so the pill toggles between `Charging ⚡️` and `Eclipse 🌑` as the satellite orbits.

### Testing
- Served the demo locally with `python3 -m http.server 4173` and confirmed the page loaded successfully. 
- Ran browser automation with Playwright Firefox to open the page and capture a screenshot, which completed successfully and produced a screenshot artifact. 
- Attempted Playwright Chromium which crashed in this environment (browser process received SIGSEGV), so Chromium-based automation failed but Firefox validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984f36e33d48326a690b11a6469e22a)