### PR TITLE
Add hold-to-image (Imaging 🌎) mode when sunlit and update charging icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,14 @@
     }
   </script>
   <style>
-    body { margin: 0; overflow: hidden; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    body {
+      margin: 0;
+      overflow: hidden;
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      -webkit-user-select: none;
+      user-select: none;
+      -webkit-touch-callout: none;
+    }
     canvas { display: block; }
 
     #status-pill {
@@ -43,10 +50,16 @@
       background: rgba(255, 146, 146, 0.95);
       border-color: #b53333;
     }
+
+    #status-pill.imaging {
+      color: #00385e;
+      background: rgba(165, 218, 255, 0.95);
+      border-color: #2b75b6;
+    }
   </style>
 </head>
 <body>
-  <div id="status-pill" class="charging">Charging ⚡️</div>
+  <div id="status-pill" class="charging">Charging ☀️</div>
   <script type="module" src="main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Allow users to press-and-hold (touch or left-click) to switch the UI into an `Imaging 🌎` mode while the satellite is on the sunlit side, preventing viewport selection/panning during the hold gesture.
- Update the charging indicator to use the sun emoji for clarity (`☀️` instead of `⚡️`).

### Description
- Added `#status-pill.imaging` CSS and adjusted `body` to disable text selection and touch-callout in `index.html` to improve hold interactions.
- Replaced the initial/status charging label text from `Charging ⚡️` to `Charging ☀️` in `index.html` and runtime status updates in `main.js`.
- Implemented imaging state in `main.js` with `isImaging`/`isSunFacing` flags and a centralized `updateStatusPill()` helper to switch between `imaging`, `charging`, and `eclipse` styles and labels.
- Added pointer handlers (`pointerdown`, `pointerup`, `pointercancel`) that disable `OrbitControls` while holding, enter `Imaging` only when sunlit, and restore controls/status on release or blur; also added touch mapping for `OrbitControls` (`controls.touches.ONE`/`TWO`).

### Testing
- Ran `node --check main.js` to validate the JS syntax; this completed successfully.
- Served the app with `python3 -m http.server 4173` and performed a Playwright script that navigated to `http://127.0.0.1:4173`, simulated a pointer hold, and captured a screenshot to verify the `Imaging 🌎` pill appears while holding on the sunlit side; this visual check succeeded.
- Confirmed the app continued to update status correctly (switching between `Charging ☀️`, `Eclipse 🌑`, and `Imaging 🌎`) during the automated interactions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69857f62629c8326a0dff919efd5784f)