### PR TITLE
Restore rotate/zoom controls and shorten long-press to 0.5s

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,11 +20,11 @@ const controls = new OrbitControls(camera, renderer.domElement);
 controls.target.set(0, 0, 0);
 controls.enableDamping = true;
 controls.dampingFactor = 0.05;
-controls.enablePan = true;
-controls.mouseButtons.MIDDLE = THREE.MOUSE.ROTATE;
-controls.mouseButtons.LEFT = THREE.MOUSE.PAN;
-controls.mouseButtons.RIGHT = THREE.MOUSE.PAN;
-controls.touches.ONE = THREE.TOUCH.PAN;
+controls.enablePan = false;
+controls.mouseButtons.LEFT = THREE.MOUSE.ROTATE;
+controls.mouseButtons.MIDDLE = THREE.MOUSE.DOLLY;
+controls.mouseButtons.RIGHT = THREE.MOUSE.ROTATE;
+controls.touches.ONE = THREE.TOUCH.ROTATE;
 controls.touches.TWO = THREE.TOUCH.DOLLY_ROTATE;
 
 // Lighting
@@ -111,7 +111,7 @@ const sunDirection = new THREE.Vector3();
 let currentStatus = '';
 let isImaging = false;
 let isSunFacing = false;
-const longPressDurationMs = 1000;
+const longPressDurationMs = 500;
 const longPressMoveTolerance = 8;
 let longPressTimerId = null;
 let activePointerId = null;


### PR DESCRIPTION
### Motivation
- Users expect rotate + zoom interactions (like the original) instead of panning, and the long-press activation felt too long and should be reduced to 0.5s.

### Description
- Updated `main.js` to disable panning by setting `controls.enablePan = false` and remapped mouse/touch bindings to restore rotate/zoom (`LEFT -> THREE.MOUSE.ROTATE`, `MIDDLE -> THREE.MOUSE.DOLLY`, `RIGHT -> THREE.MOUSE.ROTATE`, `touches.ONE -> THREE.TOUCH.ROTATE`).
- Reduced the long-press activation threshold by changing `longPressDurationMs` from `1000` to `500` milliseconds.
- File modified: `main.js`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69859ceded808326b7a8c808895cb9ba)