### PR TITLE
Increase status pill size, slow orbits, and shorten long-press delay

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,15 +24,15 @@
 
     #status-pill {
       position: fixed;
-      top: 18px;
+      top: 32px;
       left: 50%;
       transform: translateX(-50%);
-      padding: 10px 18px;
+      padding: 30px 54px;
       border-radius: 999px;
-      border: 2px solid;
-      font-size: 14px;
+      border: 6px solid;
+      font-size: 42px;
       font-weight: 700;
-      letter-spacing: 0.2px;
+      letter-spacing: 0.6px;
       pointer-events: none;
       user-select: none;
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);

--- a/main.js
+++ b/main.js
@@ -111,7 +111,7 @@ const sunDirection = new THREE.Vector3();
 let currentStatus = '';
 let isImaging = false;
 let isSunFacing = false;
-const longPressDurationMs = 500;
+const longPressDurationMs = 300;
 const longPressMoveTolerance = 8;
 let longPressTimerId = null;
 let activePointerId = null;
@@ -218,8 +218,8 @@ window.addEventListener('blur', () => {
 
 // Animation
 const clock = new THREE.Clock();
-const orbitPeriod = 10;
-const earthRotationPeriod = 55;
+const orbitPeriod = 20;
+const earthRotationPeriod = 110;
 
 function animate() {
   requestAnimationFrame(animate);


### PR DESCRIPTION
### Motivation
- Improve visibility of the status indicator on small/mobile viewports by enlarging it and adding extra top spacing.
- Make the satellite orbit and Earth's rotation noticeably slower for clearer motion observation.
- Reduce the long-press activation time to make imaging interactions feel more responsive on touch devices.

### Description
- Increased the status pill top offset and scaled the pill by updating `#status-pill` CSS in `index.html` (top, `padding`, `border`, `font-size`, and `letter-spacing`).
- Reduced the long-press threshold by changing `longPressDurationMs` from `500` to `300` in `main.js`.
- Slowed motion by doubling `orbitPeriod` from `10` to `20` and `earthRotationPeriod` from `55` to `110` in `main.js`.

### Testing
- Launched a local static server with `python -m http.server` and used a Playwright script to load `index.html` at a mobile viewport and capture `artifacts/status-pill-mobile.png`, which completed successfully.
- Verified the app still renders and that the visual status pill is larger and moved slightly further from the top in the captured mobile screenshot.
- No unit or integration test suite exists for these UI timing/CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698624451aa08326a51567b17a3137a1)