### PR TITLE
Fix flipped longitude in image location tracking

### DIFF
--- a/src/satellite.js
+++ b/src/satellite.js
@@ -44,7 +44,7 @@ export function getSubSatelliteCoordinates(earth) {
 
   return {
     lat: THREE.MathUtils.radToDeg(Math.asin(THREE.MathUtils.clamp(_localDir.y, -1, 1))),
-    lon: THREE.MathUtils.radToDeg(Math.atan2(_localDir.z, _localDir.x)),
+    lon: THREE.MathUtils.radToDeg(Math.atan2(-_localDir.z, _localDir.x)),
   };
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,7 +20,7 @@ export function vectorToLatLon(vec) {
   const normal = vec.clone().normalize();
   return {
     lat: THREE.MathUtils.radToDeg(Math.asin(THREE.MathUtils.clamp(normal.y, -1, 1))),
-    lon: THREE.MathUtils.radToDeg(Math.atan2(normal.z, normal.x)),
+    lon: THREE.MathUtils.radToDeg(Math.atan2(-normal.z, normal.x)),
   };
 }
 
@@ -31,6 +31,6 @@ export function latLonToSurfaceVector(coords, radius = EARTH_RADIUS) {
   return new THREE.Vector3(
     radius * cosLat * Math.cos(lonRad),
     radius * Math.sin(latRad),
-    radius * cosLat * Math.sin(lonRad)
+    -radius * cosLat * Math.sin(lonRad)
   );
 }


### PR DESCRIPTION
## Summary

The approximated location of each captured image was always wrong because the lat/lon emitted by the app was mirrored across the prime meridian (East ↔ West), so reverse-geocoding returned a roughly antipodal country/region and the UI showed the wrong E/W suffix.

**Root cause:** `vectorToLatLon`, `latLonToSurfaceVector`, and `getSubSatelliteCoordinates` all assumed `+Z = longitude +90° East`. But `THREE.SphereGeometry` with the default `phiStart = 0` places longitude +90° East at **-Z** (plug `phi = 3π/2` into `x = -r·cos(phi)·sin(theta)`, `z = r·sin(phi)·sin(theta)`). Combined with the standard equirectangular Earth texture (`u=0.5` = Greenwich, `u=0.75` = +90° E), this means the code's convention was sign-flipped from the rendered globe's convention. Latitude was unaffected (+Y = north pole in both).

The round-trip inside `getImagingFootprint` cancelled the sign flip internally, so the on-screen trace mesh drew at the correct visual spot — but every time we surfaced a lat/lon to the user (UI summary) or to Nominatim (geocoder), the longitude was wrong.

**Fix:** Flip the sign of the Z term symmetrically in both conversion directions and in the sub-satellite extractor. The round-trip still balances, so the trace mesh is unchanged; only the numeric lat/lon values surfaced externally change, and now match the globe.

- `src/utils.js`: `Math.atan2(-z, x)` in `vectorToLatLon`; negate the z component in `latLonToSurfaceVector`.
- `src/satellite.js`: `Math.atan2(-_localDir.z, _localDir.x)` in `getSubSatelliteCoordinates`.

The earlier "Earth rotation" hypothesis was a red herring — `getSubSatelliteCoordinates` already calls `earth.worldToLocal`, and the footprint corners live in Earth-local frame (the trace mesh is parented to `earth`), so rotation is cancelled out.

## Test plan

- [ ] Run the dev server and start the simulation.
- [ ] Trigger an imaging session over the Americas; confirm the resolved region is in the Americas (not Asia/Pacific) and the displayed longitude carries a `°W` suffix that matches the visible hemisphere.
- [ ] Trigger an imaging session over East Asia; confirm the resolved region is in Asia and the suffix is `°E`.
- [ ] Confirm the blue trace quad still appears directly under the satellite during imaging (round-trip unchanged).
- [ ] Watch the summary panel for one full orbit and cross-check `formatCoordinates` against the rendered globe.

https://claude.ai/code/session_01GsrzafLTcAMzsBTFPJReZ1